### PR TITLE
Support trialkeeper pipe outputStream flush (#782)

### DIFF
--- a/src/sdk/pynni/nni/platform/local.py
+++ b/src/sdk/pynni/nni/platform/local.py
@@ -80,7 +80,7 @@ def send_metric(string):
     if _nni_platform != 'local':
         data = (string).encode('utf8')
         assert len(data) < 1000000, 'Metric too long'    
-        print('NNISDK_ME%s' % (data))
+        print('NNISDK_ME%s' % (data), flush=True)
     else:
         data = (string + '\n').encode('utf8')
         assert len(data) < 1000000, 'Metric too long'    


### PR DESCRIPTION
In trialkeeper, the output stream of trial process may be in cache, and multiphase need the output stream returns immediately. Flush when sdk print content.